### PR TITLE
Fix BLE advertised PA level

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -85,8 +85,8 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead
-        consider-using-f-string
+        use-symbolic-message-instead,
+        consider-using-f-string,
         duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/examples/streaming_data.py
+++ b/examples/streaming_data.py
@@ -87,7 +87,7 @@ def master(count: int = 1, size: int = 32):
                 if failures > 99 and buf_iter < 7 and cnt < 2:
                     # we need to prevent an infinite loop
                     print(
-                        "Make sure slave() node is listening." " Quiting master_fifo()"
+                        "Make sure slave() node is listening. Quitting master_fifo()"
                     )
                     buf_iter = size + 1  # be sure to exit the while loop
                     radio.flush_tx()  # discard all payloads in TX FIFO
@@ -114,7 +114,7 @@ def slave(timeout: int = 5, size: int = 32):
     while time.monotonic() < start_timer + timeout:
         if radio.available():
             count += 1
-            # retreive the received packet's payload
+            # retrieve the received packet's payload
             length = radio.get_dynamic_payload_size()
             receive_payload = radio.read(length)
             print(f"Received: {receive_payload} - {count}")


### PR DESCRIPTION
This fixes an oversight in _fake_ble.py_ for which the enum value is not recognized as an int when adding the advertised PA level in a BLE payload.

<details><summary>Full traceback error</summary>

```
Traceback (most recent call last):
  File "examples/fake_ble_test.py", line 196, in <module>
    while set_role():
  File "examples/fake_ble_test.py", line 174, in set_role
    master(*[int(x) for x in user_input[1:]])
  File "examples/fake_ble_test.py", line 75, in master
    ble.advertise(battery_service.buffer, data_type=0x16)
  File "/home/pi/github/env/lib/python3.7/site-packages/pyrf24/fake_ble.py", line 616, in advertise
    payload = self.whiten(self._make_payload(payload))
  File "/home/pi/github/env/lib/python3.7/site-packages/pyrf24/fake_ble.py", line 530, in _make_payload
    pa_level = chunk(struct.pack(">b", self._radio.pa_level), 0x0A)
struct.error: required argument is not an integer
```
</details>

Also fixed some pylint & spelling errors in _streaming_data.py_ example.