### PR TITLE
update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of .gitmodules file
     schedule:
       interval: "weekly"
+      day: "friday"
     ignore:
       - dependency-name: "pybind11"
     groups:
@@ -20,6 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     groups:
       github-actions:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,8 @@ updates:
     ignore:
       - dependency-name: "pybind11"
     groups:
-      submodules:
-        patterns:
-          - "RF24*"
+      RF24-submodules:
+        patterns: ["RF24*"]
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
@@ -22,6 +21,5 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      actions:
-        patterns:
-          - "*"
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build CI
 
 on:
   pull_request:
-    types: [opened, reopened]
+    branches: [main]
   push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,12 +93,9 @@ social_cards = {
 html_theme = "sphinx_immaterial"
 html_theme_options = {
     "features": [
-        # "navigation.expand",
-        "navigation.tabs",
-        # "toc.integrate",
-        # "navigation.sections",
         "navigation.instant",
-        # "header.autohide",
+        "toc.follow",
+        "toc.sticky",
         "navigation.top",
         # "search.highlight",
         "search.share",
@@ -130,6 +127,7 @@ html_theme_options = {
     "repo_name": "pyRF24",
     # If False, expand all TOC entries
     "globaltoc_collapse": False,
+    "toc_title_is_page_title": True,
 }
 
 # turn off some features specific to sphinx-immaterial theme


### PR DESCRIPTION
I just need the PR CI to validate these changes. Ultimately, this should reduce the number of bot PRs opened: 1 PR for CI deps, and 1 PR for RF24 submodules.


> [!NOTE]
> To support python v3.13, we'll need to update pypa/cibuildwheel (CI action) and pybind11 submodule (currently pinned to v2.10.4). But Python v3.13 still in beta for now...