### PR TITLE
update pybind11 submodule to v2.13.6

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 submodules:
   include: all
 


### PR DESCRIPTION
This _should_ fix some internal CMake calls in pybind11 sources which used a deprecated API to find the currently used python version.
