### PR TITLE
Update release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          cache-image: false
 
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.22.0
@@ -44,7 +46,7 @@ jobs:
           mv ./wheelhouse/*.whl ${{ github.workspace }}/dist/
 
       - name: build source distributable wheel
-        # sdist for non-supprted platforms will serve as a stub lib install
+        # sdist for non-supported platforms will serve as a stub lib install
         run: |
           python -m pip install build
           python -m build -s
@@ -56,7 +58,7 @@ jobs:
           path: ${{ github.workspace }}/dist
 
       - name: Publish package (to TestPyPI)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@v1.12.3
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,30 +6,33 @@ on:
     types: [published]
 
 jobs:
-  upload-pypi:
-    permissions:
-      id-token: write
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [native, aarch64, armv7l]
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-
       - name: Checkout Current Repo
         uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
       - name: Install dependencies
+        if: matrix.platform == 'native'
         run: |
           sudo apt install python3-dev
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
-          python3 -m pip install twine
 
       - name: Set up QEMU
+        if: matrix.platform != 'native'
         uses: docker/setup-qemu-action@v3
         with:
           cache-image: false
@@ -37,7 +40,7 @@ jobs:
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_ARCHS_LINUX: aarch64 native armv7l
+          CIBW_ARCHS_LINUX: ${{ matrix.platform }}
           CIBW_SKIP: cp36* pp* *ppc64le *s390x
           CIBW_BUILD_VERBOSITY: 1
 
@@ -47,6 +50,7 @@ jobs:
           mv ./wheelhouse/*.whl ${{ github.workspace }}/dist/
 
       - name: build source distributable wheel
+        if: matrix.platform == 'native'
         # sdist for non-supported platforms will serve as a stub lib install
         run: |
           python -m pip install build
@@ -55,8 +59,33 @@ jobs:
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "pyRF24_pkg_dist"
+          name: pyRF24_pkg_dist_${{ matrix.platform }}
           path: ${{ github.workspace }}/dist
+
+  upload-pypi:
+    needs: [build]
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Current Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pyRF24_pkg_dist_*
+          path: dist
+          merge-multiple: true
+
+      - name: Display uploaded distributions
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: ls -r dist/
 
       - name: Publish package (to TestPyPI)
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,12 @@ jobs:
         if: matrix.platform != 'native'
         uses: docker/setup-qemu-action@v3
         with:
-          cache-image: false
+          # cached image is enabled by default.
+          # This option to disable caching doesn't exist before docker/setup-qemu-action@v3.3
+          # cache-image: false
+
+          # NOTE: the default tag `tonistiigi/binfmt:latest` is old and uses qemu v6.2.0
+          # See also https://github.com/tonistiigi/binfmt/issues/215
           image: docker.io/tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build wheels with cibuildwheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: aarch64 native armv7l
           CIBW_SKIP: cp36* pp* *ppc64le *s390x
+          CIBW_BUILD_VERBOSITY: 1
 
       - name: Move cross-compiled wheels to dist folder
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         platform: [native, aarch64, armv7l]
         python: [cp37, cp38, cp39, cp310, cp311, cp312, cp313]
+        tag: [manylinux, musllinux]
     steps:
       - name: Checkout Current Repo
         uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.platform }}
           CIBW_SKIP: pp* *ppc64le *s390x
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: '${{ matrix.python }}*'
+          CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
 
       - name: Move cross-compiled wheels to dist folder
         run: |
@@ -53,7 +54,7 @@ jobs:
 
       - name: build source distributable wheel
         # only need to do this once, preferably on a native build.
-        if: matrix.platform == 'native' && matrix.python == 'cp313'
+        if: matrix.platform == 'native' && matrix.python == 'cp313' && matrix.tag == 'manylinux'
         # sdist for non-supported platforms will serve as a stub lib install
         run: |
           python -m pip install build
@@ -62,7 +63,7 @@ jobs:
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pyRF24_pkg_dist_${{ matrix.platform }}_${{ matrix.python }}
+          name: pyRF24_pkg_dist_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}
           path: ${{ github.workspace }}/dist
 
   upload-pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           cache-image: false
+          image: docker.io/tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.22.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [native, aarch64, armv7l]
+        python: [cp37, cp38, cp39, cp310, cp311, cp312, cp313]
     steps:
       - name: Checkout Current Repo
         uses: actions/checkout@v4
@@ -41,8 +42,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.platform }}
-          CIBW_SKIP: cp36* pp* *ppc64le *s390x
+          CIBW_SKIP: pp* *ppc64le *s390x
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: '${{ matrix.python }}*'
 
       - name: Move cross-compiled wheels to dist folder
         run: |
@@ -50,7 +52,8 @@ jobs:
           mv ./wheelhouse/*.whl ${{ github.workspace }}/dist/
 
       - name: build source distributable wheel
-        if: matrix.platform == 'native'
+        # only need to do this once, preferably on a native build.
+        if: matrix.platform == 'native' && matrix.python == 'cp313'
         # sdist for non-supported platforms will serve as a stub lib install
         run: |
           python -m pip install build
@@ -59,7 +62,7 @@ jobs:
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pyRF24_pkg_dist_${{ matrix.platform }}
+          name: pyRF24_pkg_dist_${{ matrix.platform }}_${{ matrix.python }}
           path: ${{ github.workspace }}/dist
 
   upload-pypi:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ if(SKBUILD)
     message(STATUS "This project is being built using scikit-build & pybind11")
 endif()
 
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-
 include(cmake/using_flags.cmake)
 
 add_subdirectory(pybind11)
@@ -30,6 +28,7 @@ endif()
 
 # ## Build python bindings for RF24 stack into 1 binary
 pybind11_add_module(pyrf24
+    THIN_LTO
     RF24/RF24.cpp
     ${RF24_DRIVER_SOURCES}
     RF24Network/RF24Network.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ endif()
 
 # ## Build python bindings for RF24 stack into 1 binary
 pybind11_add_module(pyrf24
-    THIN_LTO
     RF24/RF24.cpp
     ${RF24_DRIVER_SOURCES}
     RF24Network/RF24Network.cpp


### PR DESCRIPTION
resolves #97 

This separates each distributed build into a matrix of jobs.

It seems the seg faults were caused by using an outdated version of QEMU. In this patch, I updated the QEMU version to v8.5.1 ([docker image](https://hub.docker.com/layers/tonistiigi/binfmt/qemu-v8.1.5/images/sha256-faf887cf973ae45b2ec15080fd7c709c31db491eefce9df0b76365ad7ef3343e))

Furthermore, this patch allows us to keep retrying failed builds without rebuilding successful builds. Consequently, this yields faster build times when publishing a release because the builds are done in parallel (instead of serially as before).