### PR TITLE
build(dev): use arm runner instead of qemu in release CI

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -2,6 +2,8 @@ version: "0.2"
 words:
   - addch
   - addstr
+  - ARCHS
+  - armv
   - attroff
   - attron
   - autoattribute
@@ -9,6 +11,8 @@ words:
   - automethod
   - calcsize
   - cbreak
+  - cibuildwheels
+  - CIBW
   - classmethod
   - crclength
   - currentmodule
@@ -27,18 +31,26 @@ words:
   - hexlified
   - HLINE
   - KBPS
+  - manylinux
   - MBPS
   - millis
   - MRAA
   - multicasted
   - multiceiver
+  - musllinux
+  - mypy
   - nocbreak
   - noecho
   - pigpio
+  - pipx
   - pybind
+  - pypa
+  - pypi
   - pyproject
+  - pypy
   - pyrf
   - repr
+  - sdist
   - seealso
   - setuptools
   - SPIDEV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.x
 
       - name: Checkout Current Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'native' && 'ubuntu-latest' || 'ubuntu-latest-arm' }}
     strategy:
       fail-fast: false
       matrix:
@@ -16,7 +16,7 @@ jobs:
         tag: [manylinux, musllinux]
     steps:
       - name: Checkout Current Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -34,16 +34,8 @@ jobs:
           python3 -m pip install -r requirements-build.txt
 
       - name: Set up QEMU
-        if: matrix.platform != 'native'
+        if: matrix.platform == 'armv7l'
         uses: docker/setup-qemu-action@v3
-        with:
-          # cached image is enabled by default.
-          # This option to disable caching doesn't exist before docker/setup-qemu-action@v3.3
-          # cache-image: false
-
-          # NOTE: the default tag `tonistiigi/binfmt:latest` is old and uses qemu v6.2.0
-          # See also https://github.com/tonistiigi/binfmt/issues/215
-          image: docker.io/tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.23.3
@@ -79,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Current Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -87,7 +79,7 @@ jobs:
           python-version: 3.x
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: pyRF24_pkg_dist_*
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,7 @@ env:
 
 run-name: >-
   Release
-  ${{ github.ref_name }}
-  ${{ github.ref_name != 'main' && '(dry-run)' }}
+  ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || (github.ref_name != 'main' && '(dry-run)' || github.ref) }}
 
 jobs:
   # sdist for non-supported platforms will serve as a stub lib install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,39 @@ jobs:
           path: dist
 
   linux:
-    runs-on: ${{ matrix.platform == 'native' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ (matrix.arch == 'aarch64' || matrix.arch == 'armv7l') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [native, aarch64, armv7l]
+        # the intention here is that each wheel is built in a separate job
+        arch: [x86_64, aarch64, armv7l]
         python: [cp37, cp38, cp39, cp310, cp311, cp312, cp313]
         tag: [manylinux, musllinux]
+        include:
+          - arch: aarch64
+            python: pp38
+            tag: manylinux
+          - arch: aarch64
+            python: pp39
+            tag: manylinux
+          - arch: aarch64
+            python: pp310
+            tag: manylinux
+          - arch: aarch64
+            python: pp311
+            tag: manylinux
+          - arch: x86_64
+            python: pp38
+            tag: manylinux
+          - arch: x86_64
+            python: pp39
+            tag: manylinux
+          - arch: x86_64
+            python: pp310
+            tag: manylinux
+          - arch: x86_64
+            python: pp311
+            tag: manylinux
     steps:
       - name: Checkout Current Repo
         uses: actions/checkout@v5
@@ -67,15 +93,15 @@ jobs:
           output-dir: dist
         # see options at https://cibuildwheel.pypa.io/en/stable/options/
         env:
-          CIBW_ARCHS_LINUX: ${{ matrix.platform }}
+          # for transparent logs
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
-          CIBW_SKIP: pp* *ppc64le *s390x
+          CIBW_BUILD: '${{ matrix.python }}-${{ matrix.tag }}_*'
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
 
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME_PREFIX }}_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}_${{ matrix.arch }}_${{ matrix.python }}_${{ matrix.tag }}
           path: dist
 
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,6 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Install dependencies
-        if: matrix.platform == 'native'
-        run: |
-          sudo apt install python3-dev
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements-build.txt
-
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.23.3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.platform == 'native' && 'ubuntu-latest' || 'ubuntu-latest-arm' }}
+    runs-on: ${{ matrix.platform == 'native' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,42 @@ name: Release Actions
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    tags: ['**']
+  pull_request:
+    branches: [main]
+
+env:
+  ARTIFACT_NAME_PREFIX: 'pyRF24_wheels'
 
 jobs:
-  build:
+  # sdist for non-supported platforms will serve as a stub lib install
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Current Repo
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+          # non-shallow checkout needed for setuptools_scm
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: build
+        run: pipx run build -s
+
+      - name: Save distributable wheels as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}_sdist
+          path: dist
+
+  linux:
     runs-on: ${{ matrix.platform == 'native' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
@@ -19,6 +50,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: true
+          # non-shallow checkout needed for setuptools_scm
           fetch-depth: 0
 
       - name: Set up Python
@@ -36,52 +68,48 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
 
-      - name: build source distributable wheel
-        # only need to do this once, preferably on a native build.
-        if: matrix.platform == 'native' && matrix.python == 'cp313' && matrix.tag == 'manylinux'
-        # sdist for non-supported platforms will serve as a stub lib install
-        run: |
-          python -m pip install build
-          python -m build -s
-
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pyRF24_pkg_dist_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}
           path: dist
 
-  upload-pypi:
-    needs: [build]
+  deploy:
+    name: >-
+      Deploy to
+      ${{ startsWith(github.ref, 'refs/tags/') && 'pypi' || 'test-pypi' }}
+      ${{ startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && '(dry run)' || '' }}
+    needs: [sdist, linux]
     permissions:
+      # needed permission for PyPI "trusted publishing"
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      # to avoid typos, set this here for easy repetition
+      DEFAULT_BRANCH: 'refs/heads/main'
     steps:
-      - name: Checkout Current Repo
-        uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
-          pattern: pyRF24_pkg_dist_*
+          pattern: ${{ env.ARTIFACT_NAME_PREFIX }}_*
           path: dist
           merge-multiple: true
 
-      - name: Display uploaded distributions
-        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
-        run: ls -r dist/
+      # if doing a dry-run (not a tag and not on main branch)
+      - name: Set up Python
+        if: github.ref != env.DEFAULT_BRANCH
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Validate distributions
+        if: github.ref != env.DEFAULT_BRANCH
+        run: pipx run twine check dist/*
 
-      - name: Publish package (to TestPyPI)
-        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+      - name: Publish package
+        # only deploy from the main branch or when a tag is pushed
+        if: github.ref == env.DEFAULT_BRANCH || startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
-          repository-url: https://test.pypi.org/legacy/
-
-      - name: Publish to PyPi
-        # only upload distributions to PyPi when triggered by a published release
-        if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+          # Only upload distributions to PyPI when triggered by a pushed tag.
+          # Otherwise, upload to test-PyPI for nightly builds on main branch.
+          repository-url: https://${{ startsWith(github.ref, 'refs/tags/') && 'upload' || 'test' }}.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,13 @@ jobs:
 
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.23.3
+        with:
+          output-dir: dist
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.platform }}
           CIBW_SKIP: pp* *ppc64le *s390x
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
-
-      - name: Move cross-compiled wheels to dist folder
-        run: |
-          mkdir -p dist
-          mv ./wheelhouse/*.whl ${{ github.workspace }}/dist/
 
       - name: build source distributable wheel
         # only need to do this once, preferably on a native build.
@@ -51,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pyRF24_pkg_dist_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}
-          path: ${{ github.workspace }}/dist
+          path: dist
 
   upload-pypi:
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,23 @@
-name: Release Actions
+name: Release CI
 
 on:
-  workflow_dispatch:
+  # to publish from main branch. 
   push:
     branches: [main]
     tags: ['**']
+  # to verify distributions before merging a PR
   pull_request:
     branches: [main]
+  # to manually trigger dry-runs on non-default branches
+  workflow_dispatch:
 
 env:
   ARTIFACT_NAME_PREFIX: 'pyRF24_wheels'
+
+run-name: >-
+  Release
+  ${{ github.ref_name }}
+  ${{ github.ref_name != 'main' && '(dry-run)' }}
 
 jobs:
   # sdist for non-supported platforms will serve as a stub lib install
@@ -53,20 +61,16 @@ jobs:
           # non-shallow checkout needed for setuptools_scm
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.23.3
         with:
           output-dir: dist
+        # see options at https://cibuildwheel.pypa.io/en/stable/options/
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.platform }}
-          CIBW_SKIP: pp* *ppc64le *s390x
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
+          CIBW_SKIP: pp* *ppc64le *s390x
 
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
@@ -78,7 +82,7 @@ jobs:
     name: >-
       Deploy to
       ${{ startsWith(github.ref, 'refs/tags/') && 'pypi' || 'test-pypi' }}
-      ${{ startsWith(github.ref, 'refs/heads/') && github.ref_name != 'main' && '(dry run)' || '' }}
+      ${{ github.ref_name != 'main' && '(dry run)' }}
     needs: [sdist, linux]
     permissions:
       # needed permission for PyPI "trusted publishing"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,6 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements-build.txt
 
-      - name: Set up QEMU
-        if: matrix.platform == 'armv7l'
-        uses: docker/setup-qemu-action@v3
-
       - name: Build wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.23.3
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ pretty = true
 [tool.ruff]
 # In addition to the standard set of exclusions, omit all tests, plus a specific file.
 extend-exclude = ["pybind11", "RF24", "RF24Network", "RF24Mesh"]
+
+[tool.cibuildwheels]
+enable = ["pypy"]


### PR DESCRIPTION
I already tested the aarch64 build on my RPi3 and RPi4.
I also tested the armv7l builds on my RPi3 (32-bit).

> [!note]
> This reduces the build time in release CI to about 2 minutes per job.
> Before this, it would take almost 10 minutes or more using qemu.

Also updated `actions/checkout` and `actions/download-artifact` in all CI workflows.