### PR TITLE
add: support for changing default GPIO chip

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -23,17 +23,20 @@ words:
   - Doherty
   - Doxyfile
   - EDDYSTONE
+  - endfunction
   - endl
   - endwin
   - getmaxyx
   - gpiochip
   - gpiod
+  - graphviz
   - hexlified
   - HLINE
   - KBPS
   - manylinux
   - MBPS
   - millis
+  - MOSI
   - MRAA
   - multicasted
   - multiceiver
@@ -41,7 +44,9 @@ words:
   - mypy
   - nocbreak
   - noecho
+  - NOMASTER
   - pigpio
+  - Pinout
   - pipx
   - pybind
   - pypa

--- a/README.rst
+++ b/README.rst
@@ -76,13 +76,11 @@ Simply use:
     python -m pip install pyrf24
 
 We have distributed binary wheels to pypi.org for easy installation and automated dependency.
-These wheels specifically target any Linux platform on ``aarch64`` architecture.
-If you're using Raspberry Pi OS (32 bit), then the above command will fetch ``armv7l`` binary
-wheels from the piwheels index (which is already configured for use in the Raspberry Pi OS).
+These wheels specifically target any Linux platform on ``aarch64``, ``armv7l``, and ``x86_64`` architectures.
 
 .. note::
-    If you're installing from a Linux machine that is not using an architecture ``aarch64``
-    or ``armv7l``, then pip may try to build the package from source code.
+    If you're installing from a Linux machine that is not using an architecture ``aarch64``,
+    ``armv7l``, or ``x86_64``, then pip may try to build the package from source code.
     In this case, you'll likely need to install some extra build dependencies:
 
     .. code-block:: bash
@@ -197,6 +195,14 @@ then it is necessary to use an environment variable containing additional argume
     .. code-block:: bash
 
         export CMAKE_ARGS="-DRF24MESH_DEBUG=ON -DRF24NETWORK_DEBUG=ON"
+
+    For RPi clones that use a different GPIO chip number, the ``CMAKE_ARGS`` can be used to adjust this too.
+    The default GPIO chip number is set to ``/dev/gpiochip0``.
+
+    .. code-block:: bash
+
+        export CMAKE_ARGS="-DRF24_LINUX_GPIO_CHIP=/dev/gpiochip4"
+
 
 Then just build and install the package from source as usual.
 

--- a/cmake/using_flags.cmake
+++ b/cmake/using_flags.cmake
@@ -2,6 +2,7 @@
 
 # ## RF24 core specific options
 option(RF24_DEBUG "enable/disable debugging output for RF24 lib" OFF)
+option(RF24_LINUX_GPIO_CHIP "select a specific GPIO chip corresponding to `/dev/gpiochipX`" /dev/gpiochip0)
 
 # ## RF24Network specific options
 option(RF24NETWORK_DEBUG "enable/disable debugging output for RF24Network lib" OFF)
@@ -81,6 +82,11 @@ function(apply_flags target)
 
     # pass driver used to expose as a constant in rf24 module.
     target_compile_definitions(${target} PUBLIC RF24_DRIVER="${RF24_DRIVER}")
+
+    if(RF24_LINUX_GPIO_CHIP)
+        message(STATUS "Setting default GPIO chip to ${RF24_LINUX_GPIO_CHIP}")
+        target_compile_definitions(${target} PUBLIC RF24_LINUX_GPIO_CHIP="${RF24_LINUX_GPIO_CHIP}")
+    endif()
 
     # apply RF24Network flags to cpp_rf24_network target
     if(RF24NETWORK_DEBUG)


### PR DESCRIPTION
Includes note in README and necessary modifications to CMake script about `target_compile_definitions()`.

resolves #102 